### PR TITLE
compare function to catch large buildings

### DIFF
--- a/comparators/large-building.js
+++ b/comparators/large-building.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var turfArea = require('turf-area');
 module.exports = largeBuilding;
 

--- a/comparators/large-building.js
+++ b/comparators/large-building.js
@@ -1,0 +1,15 @@
+var turfArea = require('turf-area');
+module.exports = largeBuilding;
+
+function largeBuilding(newVersion, oldVersion, callback) {
+  var result = {};
+  if (!newVersion) {
+    return callback(null, result);
+  }
+  var area = turfArea(newVersion);
+
+  if (area > 100000 && newVersion.properties.hasOwnProperty('building')) {
+    result['result:large-building'] = area;
+  }
+  return callback(null, result);
+}

--- a/tests/fixtures/large-building.json
+++ b/tests/fixtures/large-building.json
@@ -1,0 +1,125 @@
+{
+   "compareFunction":"large-building",
+   "fixtures":[
+      {
+         "Description":"This is a too large building input that should be caught",
+         "oldVersion": null,
+         "newVersion":{
+              "type":"Feature",
+              "properties":{
+                 "building":"yes"
+              },
+              "geometry":{
+                 "type":"Polygon",
+                 "coordinates":[
+                    [
+                       [
+                          -124.49707031249999,
+                          37.19533058280065
+                       ],
+                       [
+                          -124.49707031249999,
+                          41.04621681452063
+                       ],
+                       [
+                          -120.62988281249999,
+                          41.04621681452063
+                       ],
+                       [
+                          -120.62988281249999,
+                          37.19533058280065
+                       ],
+                       [
+                          -124.49707031249999,
+                          37.19533058280065
+                       ]
+                    ]
+                 ]
+              }
+         },
+         "expectedResult":{
+           "result:large-building": 143145029782.25003
+         }
+      },
+      {
+         "Description":"This is a small building input that should not be caught",
+         "oldVersion": null,
+         "newVersion":{
+              "type":"Feature",
+              "properties":{
+                 "building":"yes"
+              },
+              "geometry":{
+                 "type":"Polygon",
+                 "coordinates":[
+                    [
+                       [
+                         -118.36797058582306,
+                         33.81124046079714
+                       ],
+                       [
+                         -118.36797058582306,
+                         33.81136971841298
+                       ],
+                       [
+                         -118.36779892444609,
+                         33.81136971841298
+                       ],
+                       [
+                         -118.36779892444609,
+                         33.81124046079714
+                       ],
+                       [
+                         -118.36797058582306,
+                         33.81124046079714
+                       ]
+                    ]
+                 ]
+              }
+         },
+         "expectedResult":{
+
+         }
+      },
+      {
+         "Description":"This is a too large water body input that should not be caught",
+         "oldVersion": null,
+         "newVersion":{
+              "type":"Feature",
+              "properties":{
+                 "natural":"water"
+              },
+              "geometry":{
+                 "type":"Polygon",
+                 "coordinates":[
+                    [
+                       [
+                          -124.49707031249999,
+                          37.19533058280065
+                       ],
+                       [
+                          -124.49707031249999,
+                          41.04621681452063
+                       ],
+                       [
+                          -120.62988281249999,
+                          41.04621681452063
+                       ],
+                       [
+                          -120.62988281249999,
+                          37.19533058280065
+                       ],
+                       [
+                          -124.49707031249999,
+                          37.19533058280065
+                       ]
+                    ]
+                 ]
+              }
+         },
+         "expectedResult":{
+
+         }
+      }
+   ]
+}


### PR DESCRIPTION
Compare functions catches feature if it 
- has a "building" tag
- area of the the feature is > 100,000 sqkms

This will not catch other big polygons like natural, landuse etc. Only buildings. There are only 2 buildings in the world above this threshold. First 2 of the buildings in this list https://en.wikipedia.org/wiki/List_of_largest_buildings