### PR TITLE
added invalid-tag-combination compare function with fixtures

### DIFF
--- a/comparators/invalid-tag-combination.js
+++ b/comparators/invalid-tag-combination.js
@@ -1,0 +1,70 @@
+'use strict';
+/* This where all the combination of wrong tags go.
+Each array inside array in one combination and there would no cross-array verification
+*/
+var invalidTagCombinations = [
+  [
+    'highway', 'leisure'
+  ],
+  [
+    'amenity', 'highway'
+  ],
+  [
+    'highway', 'tourism'
+  ],
+  [
+    'tourism', 'landuse'
+  ],
+  [
+    'highway', 'building'
+  ],
+  [
+    'highway', 'natural'
+  ],
+  [
+    'highway', 'waterway'
+  ],
+  [
+    'place', 'shop'
+  ]
+];
+
+
+
+module.exports = invalidTagsCombined;
+
+function invalidTagsCombined(newVersion, oldVersion, callback) {
+  var result = {};
+  result['result:invalid-tag-combination'] = {};
+
+  /* Ignore all deleted feature versions */
+  if (!newVersion) {
+    return callback(null, {});
+  }
+
+
+  var newProps = newVersion.properties;
+
+  /* Loop over each array inside the main array */
+  var foundCombination;
+
+  for (var i = 0; i < invalidTagCombinations.length; i++) {
+    var combination = invalidTagCombinations[i];
+
+    var hasAllTags = combination.reduce(function(acc, tag) {
+      return acc && (tag in newProps);
+    }, true);
+
+    if (hasAllTags) {
+      foundCombination = combination;
+      break;
+    }
+  }
+
+  if (foundCombination) {
+    result['result:invalid-tag-combination'].combination = foundCombination;
+    return callback(null, result);
+  }
+
+  return callback(null, {});
+}

--- a/tests/fixtures/invalid-tag-combination.json
+++ b/tests/fixtures/invalid-tag-combination.json
@@ -1,0 +1,481 @@
+{
+  "compareFunction": "invalid-tag-combination",
+  "fixtures": [
+    {
+      "description": "has INVALID combination: highway and leisure",
+      "oldVersion": null,
+      "newVersion": {
+        "type": "Feature",
+        "geometry": {
+          "type": "LineString",
+            "coordinates": [
+            [
+              78.45440447330475,
+              17.389292746112698
+            ],
+            [
+              78.45238745212555,
+              17.389768835158964
+            ],
+            [
+              78.45265030860901,
+              17.3903165919913
+            ],
+            [
+              78.45185101032256,
+              17.390567433357653
+            ],
+            [
+              78.45166862010956,
+              17.389932650458288
+            ]
+          ]
+        },
+        "properties": {
+          "highway": "motorway",
+          "leisure": "park",
+          "name": "NH5"
+        }
+      },
+      "expectedResult": {
+        "result:invalid-tag-combination": {
+          "combination": ["highway", "leisure"]
+        }
+      }
+    },
+    {
+      "description": "has INVALID combination amenity and highway",
+      "oldVersion": null,
+      "newVersion": {
+        "type": "Feature",
+        "geometry": {
+          "type": "LineString",
+            "coordinates": [
+            [
+              78.45440447330475,
+              17.389292746112698
+            ],
+            [
+              78.45238745212555,
+              17.389768835158964
+            ],
+            [
+              78.45265030860901,
+              17.3903165919913
+            ],
+            [
+              78.45185101032256,
+              17.390567433357653
+            ],
+            [
+              78.45166862010956,
+              17.389932650458288
+            ]
+          ]
+        },
+        "properties": {
+          "highway": "primary",
+          "amenity": "hotel",
+          "name": "NH7"
+        }
+      },
+      "expectedResult": {
+        "result:invalid-tag-combination": {
+          "combination": ["amenity", "highway"]
+        }
+      }
+    },
+    {
+      "description": "has INVALID combination highway and tourism",
+      "oldVersion": null,
+      "newVersion": {
+        "type": "Feature",
+        "geometry": {
+          "type": "LineString",
+            "coordinates": [
+            [
+              78.45440447330475,
+              17.389292746112698
+            ],
+            [
+              78.45238745212555,
+              17.389768835158964
+            ],
+            [
+              78.45265030860901,
+              17.3903165919913
+            ],
+            [
+              78.45185101032256,
+              17.390567433357653
+            ],
+            [
+              78.45166862010956,
+              17.389932650458288
+            ]
+          ]
+        },
+        "properties": {
+          "name": "Limbo",
+          "highway": "trunk",
+          "tourism": "viewpoint"
+        }
+      },
+      "expectedResult": {
+        "result:invalid-tag-combination": {
+          "combination": ["highway", "tourism"]
+
+        }
+      }
+    },
+    {
+      "description": "has INVALID combination tourism and landuse",
+      "oldVersion": null,
+      "newVersion": {
+        "type": "Feature",
+        "geometry": {
+          "type": "LineString",
+            "coordinates": [
+            [
+              78.45440447330475,
+              17.389292746112698
+            ],
+            [
+              78.45238745212555,
+              17.389768835158964
+            ],
+            [
+              78.45265030860901,
+              17.3903165919913
+            ],
+            [
+              78.45185101032256,
+              17.390567433357653
+            ],
+            [
+              78.45166862010956,
+              17.389932650458288
+            ]
+          ]
+        },
+        "properties": {
+          "landuse": "residential",
+          "tourism": "viewpoint",
+          "address": "221B Baker Street"
+        }
+      },
+      "expectedResult": {
+        "result:invalid-tag-combination": {
+          "combination":["tourism","landuse"]
+
+        }
+      }
+    },
+    {
+      "description": "has INVALID combination highway and building",
+      "oldVersion": null,
+      "newVersion": {
+        "type": "Feature",
+        "geometry": {
+          "type": "LineString",
+            "coordinates": [
+            [
+              78.45440447330475,
+              17.389292746112698
+            ],
+            [
+              78.45238745212555,
+              17.389768835158964
+            ],
+            [
+              78.45265030860901,
+              17.3903165919913
+            ],
+            [
+              78.45185101032256,
+              17.390567433357653
+            ],
+            [
+              78.45166862010956,
+              17.389932650458288
+            ]
+          ]
+
+        },
+        "properties": {
+          "highway": "residential",
+          "building": "yes",
+          "name": "building"
+        }
+      },
+      "expectedResult": {
+        "result:invalid-tag-combination": {
+          "combination":["highway","building"]
+
+        }
+      }
+    },
+    {
+      "description": "has INVALID combination highway and natural",
+      "oldVersion": null,
+      "newVersion": {
+        "type": "Feature",
+        "geometry": {
+          "type": "LineString",
+            "coordinates": [
+            [
+              78.45440447330475,
+              17.389292746112698
+            ],
+            [
+              78.45238745212555,
+              17.389768835158964
+            ],
+            [
+              78.45265030860901,
+              17.3903165919913
+            ],
+            [
+              78.45185101032256,
+              17.390567433357653
+            ],
+            [
+              78.45166862010956,
+              17.389932650458288
+            ]
+          ]
+
+        },
+        "properties": {
+          "highway": "residential",
+          "natural": "water",
+          "name": "Lake"
+        }
+      },
+      "expectedResult": {
+        "result:invalid-tag-combination": {
+          "combination":["highway","natural"]
+
+        }
+      }
+    },
+    {
+      "description": "has INVALID combination highway and waterway",
+      "oldVersion": null,
+      "newVersion": {
+        "type": "Feature",
+        "geometry": {
+          "type": "LineString",
+            "coordinates": [
+            [
+              78.45440447330475,
+              17.389292746112698
+            ],
+            [
+              78.45238745212555,
+              17.389768835158964
+            ],
+            [
+              78.45265030860901,
+              17.3903165919913
+            ],
+            [
+              78.45185101032256,
+              17.390567433357653
+            ],
+            [
+              78.45166862010956,
+              17.389932650458288
+            ]
+          ]
+
+        },
+        "properties": {
+          "highway": "residential",
+          "waterway": "stream",
+          "name": "Bow"
+        }
+      },
+      "expectedResult": {
+        "result:invalid-tag-combination": {
+          "combination":["highway","waterway"]
+
+        }
+      }
+    },
+    {
+      "description": "has INVALID combination place and shop",
+      "oldVersion": null,
+      "newVersion": {
+        "type": "Feature",
+        "geometry": {
+          "type": "LineString",
+            "coordinates": [
+            [
+              78.45440447330475,
+              17.389292746112698
+            ],
+            [
+              78.45238745212555,
+              17.389768835158964
+            ],
+            [
+              78.45265030860901,
+              17.3903165919913
+            ],
+            [
+              78.45185101032256,
+              17.390567433357653
+            ],
+            [
+              78.45166862010956,
+              17.389932650458288
+            ]
+          ]
+
+        },
+        "properties": {
+          "place": "island",
+          "shop": "supermarket",
+          "name": "Fresh island animals"
+        }
+      },
+      "expectedResult": {
+        "result:invalid-tag-combination": {
+          "combination":["place","shop"]
+
+        }
+      }
+    },
+    {
+      "description": "has VALID combination place and name",
+      "oldVersion": null,
+      "newVersion": {
+        "type": "Feature",
+        "geometry": {
+          "type": "LineString",
+            "coordinates": [
+            [
+              78.45440447330475,
+              17.389292746112698
+            ],
+            [
+              78.45238745212555,
+              17.389768835158964
+            ],
+            [
+              78.45265030860901,
+              17.3903165919913
+            ],
+            [
+              78.45185101032256,
+              17.390567433357653
+            ],
+            [
+              78.45166862010956,
+              17.389932650458288
+            ]
+          ]
+
+        },
+        "properties": {
+          "place": "island",
+          "administrative": "disputed",
+          "name": "Fresh island animals"
+        }
+      },
+      "expectedResult": {
+
+      }
+    },
+    {
+      "description": "has VALID combination highway and name",
+      "oldVersion": null,
+      "newVersion": {
+        "type": "Feature",
+        "geometry": {
+          "type": "LineString",
+            "coordinates": [
+            [
+              78.45440447330475,
+              17.389292746112698
+            ],
+            [
+              78.45238745212555,
+              17.389768835158964
+            ],
+            [
+              78.45265030860901,
+              17.3903165919913
+            ],
+            [
+              78.45185101032256,
+              17.390567433357653
+            ],
+            [
+              78.45166862010956,
+              17.389932650458288
+            ]
+          ]
+
+        },
+        "properties": {
+          "highway": "trunk",
+          "lanes": "4",
+          "name": "NH15"
+        }
+      },
+      "expectedResult": {
+
+      }
+    },
+    {
+      "description": "has VALID combination natural and waterway",
+      "oldVersion": null,
+      "newVersion": {
+        "type": "Feature",
+        "geometry": {
+          "type": "LineString",
+            "coordinates": [
+            [
+              78.45440447330475,
+              17.389292746112698
+            ],
+            [
+              78.45238745212555,
+              17.389768835158964
+            ],
+            [
+              78.45265030860901,
+              17.3903165919913
+            ],
+            [
+              78.45185101032256,
+              17.390567433357653
+            ],
+            [
+              78.45166862010956,
+              17.389932650458288
+            ]
+          ]
+
+        },
+        "properties": {
+          "natural": "water",
+          "waterway": "river",
+          "name": "Amazon"
+        }
+      },
+      "expectedResult": {
+
+      }
+    }
+
+
+
+
+
+
+
+  ]
+}


### PR DESCRIPTION
Added a starting set of pairs of invalid feature tag combinations.


![screenshot 2016-12-17 17 58 42](https://cloud.githubusercontent.com/assets/8921295/21286757/932e37dc-c482-11e6-8a6c-4148f1b38f8d.png)

- We can keep adding pairs of invalid/implausible tag combinations to this list as we see fit and also change the structure of the matrix in future as we move forward.



cc @planemad @maning @krishnanammala @chtnha @batpad @geohacker 