### PR TITLE
Pokemon edits

### DIFF
--- a/comparators/pokemon_edits.js
+++ b/comparators/pokemon_edits.js
@@ -4,35 +4,34 @@ var filtered_tags = ['natural', 'water', 'highway', 'building', 'leisure', 'tour
 module.exports = pokemonEdits;
 
 function hasPokename(name) {
-    return name.match(/(P|p)ok(é|e)((m|M)on|(S|s)top|(G|g)ym|(G|g)o)/g) ||
+  return name.match(/(P|p)ok(é|e)((m|M)on|(S|s)top|(G|g)ym|(G|g)o)/g) ||
     name.match(/(P|p)ok(é|e)/g);
 }
 
 function pokemonEdits(newVersion, oldVersion, callback) {
-var result = {};
-result['result:pokemonEdits'] = {};
+  var result = {};
+  result['result:pokemonEdits'] = {};
 
-if (!newVersion && !oldVersion) {
-  // None of old version or new Version present
-  return callback(null, {});
-}
-if (newVersion) {
-
-  var pass = filtered_tags.reduce(function(accum, tag) {
-  return (tag in newVersion.properties) || accum;
-}, false);
-
-  if (pass){
-    for (var prop in newVersion.properties){
-      if (prop.indexOf('name') == 0){
-        if(hasPokename(newVersion.properties[prop])) {
-          result['result:pokemonEdits'] = true;
-          return callback(null, result);
-        } 
-      }
-    } 
+  if (!newVersion && !oldVersion) {
+    // None of old version or new Version present
+    return callback(null, {});
   }
-}
+  if (newVersion) {
+    var pass = filtered_tags.reduce(function(accum, tag) {
+      return (tag in newVersion.properties) || accum;
+    }, false);
 
-callback(null, result);
+    if (pass) {
+      for (var prop in newVersion.properties) {
+        if (prop.indexOf('name') === 0) {
+          if (hasPokename(newVersion.properties[prop])) {
+            result['result:pokemonEdits'] = true;
+            return callback(null, result);
+          }
+        }
+      }
+    }
+  }
+
+  callback(null, {});
 }

--- a/comparators/pokemon_edits.js
+++ b/comparators/pokemon_edits.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var filtered_tags = ['natural', 'water', 'highway', 'building', 'leisure', 'tourism'];
+module.exports = pokemonEdits;
+
+function hasPokename(name) {
+    return name.match(/(P|p)ok(é|e)((m|M)on|(S|s)top|(G|g)ym|(G|g)o)/g) ||
+    name.match(/(P|p)ok(é|e)/g);
+}
+
+function pokemonEdits(newVersion, oldVersion, callback) {
+var result = {};
+result['result:pokemonEdits'] = {};
+
+if (!newVersion && !oldVersion) {
+  // None of old version or new Version present
+  return callback(null, {});
+}
+if (newVersion) {
+
+  var pass = filtered_tags.reduce(function(accum, tag) {
+  return (tag in newVersion.properties) || accum;
+}, false);
+
+  if (pass){
+    for (var prop in newVersion.properties){
+      if (prop.indexOf('name') == 0){
+        if(hasPokename(newVersion.properties[prop])) {
+          result['result:pokemonEdits'] = true;
+          return callback(null, result);
+        } 
+      }
+    } 
+  }
+}
+
+callback(null, result);
+}

--- a/index.js
+++ b/index.js
@@ -14,5 +14,6 @@ module.exports = {
   'place_edited': require('./comparators/place-edited'),
   'major_name_modification': require('./comparators/major-name-modification'),
   'wikidata': require('./comparators/wikidata'),
-  'null_island': require('./comparators/null-island')
+  'null_island': require('./comparators/null-island'),
+  'pokemon_edits': require('./comparators/pokemon_edits')
 };

--- a/tests/fixtures/pokemon_edits.json
+++ b/tests/fixtures/pokemon_edits.json
@@ -50,6 +50,55 @@
     "expectedResult" : {
       "result:pokemonEdits": true
     }
+  },
+  {
+    "description": "not pokemon edits",
+        "newVersion": {
+            "type": "Feature",
+            "id": "node!4412655090!2",
+            "properties": {
+                "tourism": "hotel",
+                "name:": "A2B",
+                "osm:type": "node",
+                "osm:id": 4412655090,
+                "osm:version": 2,
+                "osm:changeset": 43885598,
+                "osm:timestamp": 1479870698000,
+                "osm:uid": 1306,
+                "osm:user": "PlaneMad"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    72.5451861,
+                    23.2005836
+                ]
+            }
+        },
+        "oldVersion": {
+            "type": "Feature",
+            "id": "node!4412655090!1",
+            "properties": {
+                "tourism": "hotel",
+                "name": "Washington Park",
+                "osm:type": "node",
+                "osm:id": 4412655090,
+                "osm:version": 1,
+                "osm:changeset": 42338212,
+                "osm:timestamp": 1474519696000,
+                "osm:uid": 4112063,
+                "osm:user": "kailashdhirwani"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    72.5451861,
+                    23.2005836
+                ]
+            }
+        },
+    "expectedResult" : {
+    }
   }
-  ]
+    ]
 }

--- a/tests/fixtures/pokemon_edits.json
+++ b/tests/fixtures/pokemon_edits.json
@@ -1,0 +1,55 @@
+{
+  "compareFunction": "pokemon_edits",
+  "fixtures": [
+  {
+    "description": "pokemon edits",
+        "newVersion": {
+            "type": "Feature",
+            "id": "node!4412655090!2",
+            "properties": {
+                "tourism": "hotel",
+                "name:": "poké",
+                "osm:type": "node",
+                "osm:id": 4412655090,
+                "osm:version": 2,
+                "osm:changeset": 43885598,
+                "osm:timestamp": 1479870698000,
+                "osm:uid": 1306,
+                "osm:user": "PlaneMad"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    72.5451861,
+                    23.2005836
+                ]
+            }
+        },
+        "oldVersion": {
+            "type": "Feature",
+            "id": "node!4412655090!1",
+            "properties": {
+                "tourism": "hotel",
+                "name": "Washington Park",
+                "osm:type": "node",
+                "osm:id": 4412655090,
+                "osm:version": 1,
+                "osm:changeset": 42338212,
+                "osm:timestamp": 1474519696000,
+                "osm:uid": 4112063,
+                "osm:user": "kailashdhirwani"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    72.5451861,
+                    23.2005836
+                ]
+            }
+        },
+    "expectedResult" : {
+      "result:pokemonEdits": true
+    }
+  }
+  ]
+}


### PR DESCRIPTION
As a part of Pokemon edits,

Compare function for  change in `name` or `name:*` tag to any of these `"~"pok(é|e(mon|stop|gym|go)"` for the features like `natural`, `water` , `highway`, `building`, `leisure`, `tourism` will be flagged.


cc @maning @batpad @amishas157 @geohacker 

