### PR TITLE
Non english characters in name:en

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 *.spatialite
+data

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "eslint": "^2.8.0",
     "eslint-config-mourner": "^2.0.1",
-    "tap": "^5.7.1"
+    "tap": "^5.7.1",
+    "tile-reduce": "^3.1.1"
   }
 }

--- a/scripts/non-english/explore.js
+++ b/scripts/non-english/explore.js
@@ -1,0 +1,39 @@
+var argv = require('minimist')(process.argv.slice(2));
+var readline = require('readline');
+var fs = require('fs');
+
+if (!argv.features) {
+    console.log('');
+    console.log('USAGE: node explore.js [OPTIONS]');
+    console.log('');
+    console.log('  OPTIONS:');
+    console.log('    --features     features.json');
+    console.log('');
+    return;
+}
+
+var reader = readline.createInterface({
+    input: fs.createReadStream(argv.features),
+    output: null
+});
+
+function isWhitelisted(character) {
+    var whitelist = '–é—’‘ńűšćőžāėŠ→ș';
+    for (var i = 0; i < whitelist.length; i++) {
+        if (character === whitelist[i]) return true;
+    }
+    return false;
+}
+
+reader.on('line', function (line) {
+
+    var feature = JSON.parse(line);
+    var name = feature.properties['name:en'];
+
+    var nonEnglishCount = 0;
+    for (var i = 0; i < name.length; i++) {
+        if (name.charCodeAt(i) > 127) nonEnglishCount += 1;
+    }
+    if (nonEnglishCount >= 5) console.log(JSON.stringify(feature));
+
+});

--- a/scripts/non-english/extract.js
+++ b/scripts/non-english/extract.js
@@ -8,7 +8,7 @@ module.exports = function (tileLayers, tile, writeData, done) {
         if (feature.properties.hasOwnProperty('name:en')) {
             var name = feature.properties['name:en'];
             for (var j = 0; j < name.length; j++) {
-                if (name.charCodeAt(j) > 127) {
+                if (name.charCodeAt(j) > 255) {
                     results.push(JSON.stringify(feature));
                     break;
                 }

--- a/scripts/non-english/extract.js
+++ b/scripts/non-english/extract.js
@@ -1,0 +1,23 @@
+module.exports = function (tileLayers, tile, writeData, done) {
+    var osm = tileLayers.osm.osm;
+
+    var results = [];
+    for (var i = 0; i < osm.features.length; i++) {
+        var feature = osm.features[i];
+
+        if (feature.properties.hasOwnProperty('name:en')) {
+            var name = feature.properties['name:en'];
+            for (var j = 0; j < name.length; j++) {
+                if (name.charCodeAt(j) > 127) {
+                    results.push(JSON.stringify(feature));
+                    break;
+                }
+            }
+        }
+    }
+
+    if (results.length > 0) {
+        process.stdout.write('\n' + results.join('\n') + '\n');
+    }
+    done(null, null);
+};

--- a/scripts/non-english/index.js
+++ b/scripts/non-english/index.js
@@ -1,0 +1,20 @@
+var tileReduce = require('tile-reduce');
+var argv = require('minimist')(process.argv.slice(2));
+var path = require('path');
+
+if (!argv.osm) {
+    console.log('');
+    console.log('node index OPTIONS');
+    console.log('');
+    console.log('  OPTIONS');
+    console.log('    --osm osm-qa-tiles.mbtiles');
+    console.log('');
+    return;
+}
+
+tileReduce({
+    bbox: [77.55180358886719, 12.951698393721799, 77.61428833007812, 13.017269075810677],
+    zoom: 12,
+    map: path.join(__dirname, 'extract.js'),
+    sources: [{ name: 'osm', mbtiles: argv.osm }],
+});


### PR DESCRIPTION

<img width="1177" alt="screen shot 2017-03-08 at 11 04 23 am" src="https://cloud.githubusercontent.com/assets/2899501/23691531/0d28feae-03ef-11e7-96d7-80fb147b5766.png">


Per scrum yesterday having non-english alphabets in `name:en` tags is not ideal. Ran a quick tile-reduce script to extract features on OpenStreetMap with a non English character in `name:en`.

- Found `5373` features with **5 or more non-English characters** in the `name:en` field.
- [File on Dropbox](https://www.dropbox.com/s/v807enwur50z96h/five-or-more-non-english-characters-20170308.json?dl=0) with with features as line-delimited Geojson's
- Script: `scripts/non-english/explore.js`

## Next actions
- [ ] Should we turn this into a compare function?
- [ ] Will this be better on [`osmlint`](https://github.com/osmlab/osmlint/) cc: @Rub21 


## Notes
- Some features have both English and non-English content in their `name:en` field. Ex: [`မောလမြိင်တက္ကသိုလ် - Mawlamyaing Uni`](http://www.openstreetmap.org/way/229045595)
- There are some interesting `name:en` which are not part of the list ^ as there are only one non-English character. Ex:
    - `ž` in `Gruža`
    - `ș` in the `Oaș Land Museum`


---

cc: @krishnanammala @maning 