### PR TITLE
Increase threshold for large building comparator

### DIFF
--- a/comparators/large-building.js
+++ b/comparators/large-building.js
@@ -10,7 +10,7 @@ function largeBuilding(newVersion, oldVersion, callback) {
   }
   var area = turfArea(newVersion);
 
-  if (area > 1500 && newVersion.properties.hasOwnProperty('building')) {
+  if (area > 5000 && newVersion.properties.hasOwnProperty('building')) {
     result['result:large-building'] = area;
   }
   return callback(null, result);


### PR DESCRIPTION
Large building comparator is definitely noisy. Currently it is 1500m^2 . Increased it to 5000 to see what the incoming rate would be like.


cc @geohacker @batpad @bkowshik @amishas157 @maning 