### PR TITLE
Test compare function with/without callback

### DIFF
--- a/tests/test_compare_function.js
+++ b/tests/test_compare_function.js
@@ -15,15 +15,15 @@ var compareFunctionPath = path.join('../', 'comparators', jsonData.compareFuncti
 var compareFunction = require(compareFunctionPath);
 
 jsonData.fixtures.forEach(function (fixture) {
-  compareFunction(fixture.newVersion, fixture.oldVersion, function(error, result) {
-    console.log(fixture.description);
-    console.log('expected', fixture.expectedResult);
-    if (error) console.log(error);
-    console.log('actual', JSON.stringify(result), '\n');
-    if (JSON.stringify(fixture.expectedResult) !== JSON.stringify(result)) {
-      console.log('Test failed! Actual is not expected!');
-    } else {
-      console.log('Test passed! Actual is same as expected');
-    }
-  });
+  var result = compareFunction(fixture.newVersion, fixture.oldVersion);
+
+  console.log(fixture.description);
+  console.log('expected', fixture.expectedResult);
+
+  console.log('actual', JSON.stringify(result), '\n');
+  if (JSON.stringify(fixture.expectedResult) !== JSON.stringify(result)) {
+    console.log('Test failed! Actual is not expected!');
+  } else {
+    console.log('Test passed! Actual is same as expected');
+  }
 });


### PR DESCRIPTION
There are a couple of compare functions with the old style `callback` format. Ex:
- [`invalid_tag_combination.js`](https://github.com/mapbox/osm-compare/blob/callback-and-no-callback/comparators/invalid_tag_combination.js)

A majority of compare function have moved over to the new, plain return format. Ex:
- [`added_place.js`](https://github.com/mapbox/osm-compare/blob/callback-and-no-callback/comparators/added_place.js)

---

@batpad @lukasmartinelli Any ideas how to make [`tests/test_compare_function.js`](https://github.com/mapbox/osm-compare/blob/master/tests/test_compare_function.js) work for both these use cases? In this PR, I have modified the test to work for the plain return format as that looks like the majority of the compare functions.

---

cc: @amishas157 @geohacker 