### PR TITLE
Remove village, hamlet and island from the place-edited list

### DIFF
--- a/comparators/place_edited.js
+++ b/comparators/place_edited.js
@@ -7,10 +7,7 @@ var _ = require('lodash');
 - If a feature has these tags
     - place=city
     - place=town
-    - place=village
     - place=suburb
-    - place=hamlet
-    - place=island
 
 - Any of the following are true:
   - The feature is deleted **or**
@@ -48,10 +45,7 @@ function getIsPlace(geojson) {
   var placeValues = [
     'city',
     'town',
-    'village',
-    'suburb',
-    'hamlet',
-    'island'
+    'suburb'
   ];
   return geojson.properties &&
     geojson.properties.place &&
@@ -93,4 +87,3 @@ function getNameChanged(newVersion, oldVersion) {
   }
   return nameChanged;
 }
-

--- a/tests/fixtures/place_edited.json
+++ b/tests/fixtures/place_edited.json
@@ -10,7 +10,7 @@
                     "osm:type": "node",
                     "osm:uid": 123,
                     "osm:changeset": 123,
-                    "place": "village"
+                    "place": "suburb"
                 },
                 "geometry": {
                     "type": "Point",
@@ -27,7 +27,7 @@
                     "osm:type": "node",
                     "osm:uid": 124,
                     "osm:changeset": 124,
-                    "place": "village"
+                    "place": "suburb"
                 },
                 "geometry": {
                     "type": "Point",
@@ -121,6 +121,6 @@
             "expectedResult": {
                 "result:place_edited": true
             }
-        }        
+        }
     ]
 }


### PR DESCRIPTION
Thinking of closing: https://github.com/mapbox/osm-compare/issues/134 in two separate steps. This PR, removes the `village`, `hamlet` and `island` features from the list.

@krishnanammala can you 👀 this PR and give me a 👍 before we merge this?