### PR TITLE
Comparator to flag invalid names of features

### DIFF
--- a/comparators/README.md
+++ b/comparators/README.md
@@ -87,3 +87,6 @@ Report when a new user creates a new water feature.
 
 ### invalid-tag-modification
 Reports when a feature's primary tag is modified between newVersion and oldVersion of the feature.
+
+### invalid_name
+Report if a values of `name` or `name:*` for a feature have any profanity.

--- a/comparators/invalid_name.js
+++ b/comparators/invalid_name.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = invalidName;
+
+function invalidName(newVersion, oldVersion, callback) {
+
+  // Not interested if there isn't a newVersion.
+  if (!newVersion) return callback(null, {});
+
+
+  var properties = newVersion.properties;
+  for (var key in properties) {
+    if (key === 'name') {
+      var naughtyWords = require('naughty-words/en.json');
+      if (naughtyWords.indexOf(properties[key]) !== -1) return callback(null, {'result:invalid_name': true});
+    }
+  }
+  return callback(null, {});
+}

--- a/comparators/invalid_name.js
+++ b/comparators/invalid_name.js
@@ -7,12 +7,28 @@ function invalidName(newVersion, oldVersion, callback) {
   // Not interested if there isn't a newVersion.
   if (!newVersion) return callback(null, {});
 
-
   var properties = newVersion.properties;
   for (var key in properties) {
+    var naughtyWords;
+
+    // TODO: Having English as the default locale for now.
     if (key === 'name') {
-      var naughtyWords = require('naughty-words/en.json');
+      naughtyWords = require('naughty-words/en.json');
       if (naughtyWords.indexOf(properties[key]) !== -1) return callback(null, {'result:invalid_name': true});
+    } else if (key.indexOf('name') === 0) {
+      // Splitting 'name:ko' into ['name', 'ko']
+      var locale = key.split(':')[1];
+
+      // Name of the locale's naughty word file.
+      var filename = 'naughty-words/' + locale + '.json';
+
+      try {
+        naughtyWords = require(filename);
+        if (naughtyWords.indexOf(properties[key]) !== -1) return callback(null, {'result:invalid_name': true});
+      } catch (error) {
+        // TODO: naughty-words for the locale does not exist. Skip for now.
+      }
+
     }
   }
   return callback(null, {});

--- a/index.js
+++ b/index.js
@@ -29,5 +29,6 @@ module.exports = {
   'name_matches_to_wikidata': require('./comparators/name_matches_to_wikidata.js'),
   'name_modified': wrapsync(require('./comparators/name_modified.js')),
   'osm_landmarks': require('./comparators/osm_landmarks.js'),
-  'invalid_tag_modification': require('./comparators/invalid_tag_modification')
+  'invalid_tag_modification': require('./comparators/invalid_tag_modification'),
+  'invalid_name': require('./comparators/invalid_name')
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "levenshtein": "^1.0.5",
     "lodash": "^4.17.3",
     "moment": "^2.17.1",
+    "naughty-words": "^1.0.1",
     "osm-landmarks": "^0.3.1",
     "queue-async": "^1.2.1",
     "request": "^2.72.0",

--- a/tests/fixtures/invalid_name.json
+++ b/tests/fixtures/invalid_name.json
@@ -24,6 +24,30 @@
         "geometry": null
       },
       "oldVersion": null
+    },
+    {
+      "description": "Test feature with profanity in name:* tag",
+      "expectedResult": {"result:invalid_name": true},
+      "newVersion": {
+        "type": "Feature",
+        "properties": {
+          "name:ko": "강간"
+        },
+        "geometry": null
+      },
+      "oldVersion": null
+    },
+    {
+      "description": "Test feature with profanity in name:* tag when naughty-words does not exist for the locale",
+      "expectedResult": {},
+      "newVersion": {
+        "type": "Feature",
+        "properties": {
+          "name:kn": "xxx"
+        },
+        "geometry": null
+      },
+      "oldVersion": null
     }
   ]
 }

--- a/tests/fixtures/invalid_name.json
+++ b/tests/fixtures/invalid_name.json
@@ -1,0 +1,29 @@
+{
+  "compareFunction": "invalid_name",
+  "fixtures": [
+    {
+      "description": "Test feature with name tag but without profanity",
+      "expectedResult": {},
+      "newVersion": {
+        "type": "Feature",
+        "properties": {
+          "name": "Hello, world!"
+        },
+        "geometry": null
+      },
+      "oldVersion": null
+    },
+    {
+      "description": "Test feature with profanity in name tag",
+      "expectedResult": {"result:invalid_name": true},
+      "newVersion": {
+        "type": "Feature",
+        "properties": {
+          "name": "xxx"
+        },
+        "geometry": null
+      },
+      "oldVersion": null
+    }
+  ]
+}


### PR DESCRIPTION
Makes progress on: https://github.com/mapbox/osm-compare/issues/133

---

- Check for profanity using [`naughty-words-js`](https://github.com/LDNOOBW/naughty-words-js) package.