### PR TITLE
Remove escalate for lake and name mod

### DIFF
--- a/comparators/major_lake_modified.js
+++ b/comparators/major_lake_modified.js
@@ -63,8 +63,7 @@ function majorLakeModified(newVersion, oldVersion) {
   var osmId = props['osm:id'];
   if (osmType === 'relation' && lakeIds.indexOf(osmId) !== -1) {
     return {
-      'result:major_lake_modified': true,
-      'result:escalate': true
+      'result:major_lake_modified': true
     };
   } else {
     return {};

--- a/comparators/major_name_modification.js
+++ b/comparators/major_name_modification.js
@@ -21,8 +21,7 @@ function majorNameModification(newVersion, oldVersion) {
   if (modification >= 50 && newVersion.properties['osm:version'] > 10) {
     return {
       'result:major_name_modification': true,
-      'result:levenshtein_distance': distance,
-      'result:escalate': true
+      'result:levenshtein_distance': distance
     };
   }
 

--- a/tests/fixtures/major_lake_modified.json
+++ b/tests/fixtures/major_lake_modified.json
@@ -534,8 +534,7 @@
         }
       },
       "expectedResult": {
-        "result:major_lake_modified": true,
-        "result:escalate": true
+        "result:major_lake_modified": true
       }
     },
     {

--- a/tests/fixtures/major_name_modification.json
+++ b/tests/fixtures/major_name_modification.json
@@ -67,8 +67,7 @@
       },
       "expectedResult": {
         "result:major_name_modification": true,
-        "result:levenshtein_distance": 8,
-        "result:escalate": true
+        "result:levenshtein_distance": 8
       }
     },
     {
@@ -92,8 +91,7 @@
       },
       "expectedResult": {
         "result:major_name_modification": true,
-        "result:levenshtein_distance": 10,
-        "result:escalate": true
+        "result:levenshtein_distance": 10
       }
     },
     {


### PR DESCRIPTION
Part of https://github.com/mapbox/osm-quarantine/pull/160
Major name detector is live so these alarms are all coverd by qurantine.