### PR TITLE
Format hook

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
     "consistent-return": 0,
     "no-unused-vars": 0,
     "camelcase": 0,
-    "valid-jsdoc": 2
+    "valid-jsdoc": 2,
+    "comma-dangle": ["error", "never"]    
   }
 }

--- a/comparators/null_island.js
+++ b/comparators/null_island.js
@@ -6,22 +6,7 @@ var centroid = require('turf-centroid');
 
 module.exports = nullIsland;
 
-function nullIsland(
-  newVersion,
-  oldVersion,
-  a,
-  b,
-  sd,
-  fvd,
-  vdgf,
-  sad,
-  asd,
-  s,
-  fgggg,
-  hrgrfc,
-  sdsd,
-  wewewe
-) {
+function nullIsland(newVersion, oldVersion) {
   if (
     !newVersion ||
     !newVersion.hasOwnProperty('geometry') ||

--- a/comparators/null_island.js
+++ b/comparators/null_island.js
@@ -6,11 +6,35 @@ var centroid = require('turf-centroid');
 
 module.exports = nullIsland;
 
-function nullIsland(newVersion, oldVersion) {
-  if (!newVersion || !newVersion.hasOwnProperty('geometry') || newVersion['geometry'] === null) {
+function nullIsland(
+  newVersion,
+  oldVersion,
+  a,
+  b,
+  sd,
+  fvd,
+  vdgf,
+  sad,
+  asd,
+  s,
+  fgggg,
+  hrgrfc,
+  sdsd,
+  wewewe
+) {
+  if (
+    !newVersion ||
+    !newVersion.hasOwnProperty('geometry') ||
+    newVersion['geometry'] === null
+  ) {
     return false;
   }
-  var polygon = bboxPolygon([-10.496769839987422, -4.291703357034322, 5.252754932388029, 4.291703357043673]);
+  var polygon = bboxPolygon([
+    -10.496769839987422,
+    -4.291703357034322,
+    5.252754932388029,
+    4.291703357043673
+  ]);
   var center = centroid(newVersion);
   var inside = turfInside(center, polygon);
   if (inside) {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
     "csv": "^1.1.1",
     "eslint": "^2.8.0",
     "eslint-config-mourner": "^2.0.1",
+    "husky": "^0.13.3",
+    "lint-staged": "^3.4.0",
+    "prettier": "^0.22.0",
+    "prettier-eslint-cli": "^3.2.0",
     "tap": "^5.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,14 @@
     "test": "TAP_TIMEOUT=600 tap --coverage tests/*.js",
     "lint": "eslint ./*/*.js",
     "pretest": "npm run lint",
-    "postinstall": "./scripts/download_landmarks.sh && ./scripts/download_common_tag_values.sh"
+    "postinstall": "./scripts/download_landmarks.sh && ./scripts/download_common_tag_values.sh",
+    "precommit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.js": [
+      "prettier-eslint --write",
+      "git add"
+    ]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds the following dev dependency
- prettier
- precommit hook

The way it works is.
1. The user does some changes.
2. when he/she does `git commit -m "my fix"`.
3. A precommit hook (`prettier-eslint --write`) runs.
4. It formats the code according the `.eslintrc` file.
5. Everything happens automagically. 


cc @bkowshik @amishas157 @geohacker .
Once the PR is merged I can format the entire code base to conform to the `.eslintrc` file.

(fixes #152 )