### PR TITLE
handle deleted:true

### DIFF
--- a/comparators/added_place.js
+++ b/comparators/added_place.js
@@ -3,7 +3,7 @@
 module.exports = addedPlace;
 
 function addedPlace(newVersion, oldVersion) {
-  if (!newVersion) {
+  if (newVersion.deleted) {
     return false;
   }
   if (oldVersion) {

--- a/comparators/added_website.js
+++ b/comparators/added_website.js
@@ -3,11 +3,11 @@
 module.exports = addedWebsite;
 
 function addedWebsite(newVersion, oldVersion) {
-  if (oldVersion && oldVersion.properties && newVersion && newVersion.properties && oldVersion.properties.website === newVersion.properties.website) {
+  if (oldVersion && oldVersion.properties && !newVersion.deleted && newVersion.properties && oldVersion.properties.website === newVersion.properties.website) {
     return false;
-  } else if (newVersion && newVersion.properties && 'website' in newVersion.properties) {
+  } else if (!newVersion.deleted && newVersion.properties && 'website' in newVersion.properties) {
     return {'result:added_website': true};
-  } else if (oldVersion && oldVersion.properties && ('website' in oldVersion.properties) && newVersion && newVersion.properties && !('website' in newVersion.properties)) {
+  } else if (oldVersion && oldVersion.properties && ('website' in oldVersion.properties) && !newVersion.deleted && newVersion.properties && !('website' in newVersion.properties)) {
     return {'result:added_website': true};
   } else {
     return false;

--- a/comparators/common_tag_values.js
+++ b/comparators/common_tag_values.js
@@ -15,7 +15,7 @@ var primaryTags = [
 function commonTagValues(newVersion, oldVersion) {
   var result = false;
 
-  if (!newVersion || !newVersion.properties)
+  if (newVersion.deleted || !newVersion.properties)
     return false;
 
   var primary_tag_present = false;

--- a/comparators/disputed_border_deleted.js
+++ b/comparators/disputed_border_deleted.js
@@ -2,11 +2,11 @@
 module.exports = disputedBorderDeleted;
 
 function disputedBorderDeleted(newVersion, oldVersion) {
-  if (!newVersion && !oldVersion) {
+  if (newVersion.deleted && !oldVersion) {
   // None of old version or new Version present
     return false;
   }
-  if (!newVersion && oldVersion) {
+  if (newVersion.deleted && oldVersion) {
   // Only old Version is present, which indicates feature has been deleted
   /*
     Comparing the tags

--- a/comparators/disputed_border_tag_changed.js
+++ b/comparators/disputed_border_tag_changed.js
@@ -2,11 +2,11 @@
 module.exports = disputedBorderTagChanged;
 
 function disputedBorderTagChanged(newVersion, oldVersion) {
-  if (!newVersion && !oldVersion) {
+  if (newVersion.deleted && !oldVersion) {
   // None of old version or new Version present
     return false;
   }
-  if (newVersion && oldVersion) {
+  if (!newVersion.deleted && oldVersion) {
   // Both new Version and old Version are present, which indicates feature has been modified
   /*
     Comparing the tags

--- a/comparators/dragged_highway_waterway.js
+++ b/comparators/dragged_highway_waterway.js
@@ -6,11 +6,11 @@ var turfDistance = require('turf-distance');
 var threshold = 10;
 
 function draggedHighwayWaterway(newVersion, oldVersion) {
-  if (newVersion && oldVersion && newVersion.geometry && oldVersion.geometry) {
+  if (!newVersion.deleted && oldVersion && newVersion.geometry && oldVersion.geometry) {
     if (JSON.stringify(newVersion.geometry) === JSON.stringify(oldVersion.geometry)) return false;
   }
 
-  if (newVersion &&
+  if (!newVersion.deleted &&
     newVersion.properties &&
     (newVersion.properties.hasOwnProperty('highway') ||
     newVersion.properties.hasOwnProperty('waterway')) &&

--- a/comparators/invalid_highway_tags.js
+++ b/comparators/invalid_highway_tags.js
@@ -46,7 +46,7 @@ function invalidHighwayTags(newVersion, oldVersion) {
     'traffic_signals',
     'turning_circle'
   ];
-  if (newVersion && newVersion.properties && newVersion.properties['highway'] && validHighwayTags.indexOf(newVersion.properties.highway) === -1) {
+  if (!newVersion.deleted && newVersion.properties && newVersion.properties['highway'] && validHighwayTags.indexOf(newVersion.properties.highway) === -1) {
     return {'result:invalid_highway_tags': true};
   }
   return false;

--- a/comparators/invalid_name.js
+++ b/comparators/invalid_name.js
@@ -4,7 +4,7 @@ module.exports = invalidName;
 
 function invalidName(newVersion, oldVersion, callback) {
   // Not interested if there isn't a newVersion.
-  if (!newVersion) return callback(null, false);
+  if (newVersion.deleted) return callback(null, false);
 
   var properties = newVersion.properties;
   for (var key in properties) {

--- a/comparators/invalid_tag_combination.js
+++ b/comparators/invalid_tag_combination.js
@@ -9,7 +9,7 @@ function invalidTagCombination(newVersion, oldVersion, callback) {
   // What should be the minimum value of count to be a valid tag combination.
   var MIN_COUNT = 1;
 
-  if (!newVersion) return callback(null, false);
+  if (newVersion.deleted) return callback(null, false);
 
   csv.parse(fs.readFileSync(path.join(__dirname, 'tag-combinations.csv')), function (error, rows) {
     var tags = Object.keys(newVersion.properties);

--- a/comparators/invalid_tag_modification.js
+++ b/comparators/invalid_tag_modification.js
@@ -19,7 +19,7 @@ function getPrimaryTags(properties) {
 
 
 function invalidTagModification(newVersion, oldVersion, callback) {
-  if (!newVersion || !oldVersion) return callback(null, false);
+  if (newVersion.deleted || !oldVersion) return callback(null, false);
 
   var primaryTags = getPrimaryTags(oldVersion.properties);
   // Check if all primary tags are retained in newVersion.

--- a/comparators/large_building.js
+++ b/comparators/large_building.js
@@ -4,7 +4,7 @@ var turfArea = require('turf-area');
 module.exports = largeBuilding;
 
 function largeBuilding(newVersion, oldVersion) {
-  if (!newVersion || !newVersion.hasOwnProperty('geometry') || newVersion['geometry'] === null) {
+  if (newVersion.deleted || !newVersion.hasOwnProperty('geometry') || newVersion['geometry'] === null) {
     return false;
   }
   var area = turfArea(newVersion);

--- a/comparators/major_lake_modified.js
+++ b/comparators/major_lake_modified.js
@@ -48,7 +48,7 @@ module.exports = majorLakeModified;
 
 function majorLakeModified(newVersion, oldVersion) {
   var obj = {};
-  if (newVersion) {
+  if (!newVersion.deleted) {
     obj = newVersion;
   } else if (oldVersion) {
     obj = oldVersion;

--- a/comparators/major_name_modification.js
+++ b/comparators/major_name_modification.js
@@ -5,7 +5,7 @@ var Levenshtein = require('levenshtein');
 module.exports = majorNameModification;
 
 function majorNameModification(newVersion, oldVersion) {
-  if (!newVersion || !newVersion.properties || !newVersion.properties.name || (!(newVersion.properties.wikidata ||  newVersion.properties.wikipedia))) return false;
+  if (newVersion.deleted || !newVersion.properties || !newVersion.properties.name || (!(newVersion.properties.wikidata ||  newVersion.properties.wikipedia))) return false;
   if (!oldVersion || !oldVersion.properties || !oldVersion.properties.name) return false;
 
   // If the name tag was not modified

--- a/comparators/major_road_changed.js
+++ b/comparators/major_road_changed.js
@@ -29,18 +29,18 @@ function isMajorRoad(feature) {
 }
 
 function majorRoadChanged(newVersion, oldVersion) {
-  if (!oldVersion && !newVersion) {
+  if (!oldVersion && newVersion.deleted) {
     return false;
   }
 
-  if (!oldVersion && newVersion) {
+  if (!oldVersion && !newVersion.deleted) {
     return false;
   }
 
   var oldVersionNumber = getVersion(oldVersion);
   var oldHighwayType = getHighwayType(oldVersion);
 
-  if (oldVersion && newVersion) {
+  if (oldVersion && !newVersion.deleted) {
     var newVersionNumber = getVersion(newVersion);
     var newHighwayType = getHighwayType(newVersion);
 
@@ -57,7 +57,7 @@ function majorRoadChanged(newVersion, oldVersion) {
     }
   }
 
-  if (oldVersion && !newVersion) {
+  if (oldVersion && newVersion.deleted) {
     if (oldVersionNumber > TRIGGER_AFTER_VERSION && isMajorRoad(oldVersion)) {
       return {
         'result:major_road_changed': {

--- a/comparators/modified_monument.js
+++ b/comparators/modified_monument.js
@@ -3,11 +3,11 @@
 module.exports = modifiedMonument;
 
 function modifiedMonument(newVersion, oldVersion) {
-  if (newVersion && newVersion.properties.hasOwnProperty('historic') && newVersion.properties.historic === 'monument' && newVersion.properties['osm:version'] > 10) {
+  if (!newVersion.deleted && newVersion.properties.hasOwnProperty('historic') && newVersion.properties.historic === 'monument' && newVersion.properties['osm:version'] > 10) {
     return {'result:modified_monument': true};
   }
 
-  if (oldVersion && !newVersion && oldVersion.properties.hasOwnProperty('historic') && oldVersion.properties.historic === 'monument' && oldVersion.properties['osm:version'] > 10) {
+  if (oldVersion && newVersion.deleted && oldVersion.properties.hasOwnProperty('historic') && oldVersion.properties.historic === 'monument' && oldVersion.properties['osm:version'] > 10) {
     return {'result:modified_monument': true};
   }
   return false;

--- a/comparators/modified_place_wikidata.js
+++ b/comparators/modified_place_wikidata.js
@@ -3,7 +3,7 @@
 module.exports = modifiedPlaceWikidata;
 
 function modifiedPlaceWikidata(newVersion, oldVersion) {
-  if (!newVersion || !newVersion.properties) return false;
+  if (newVersion.deleted || !newVersion.properties) return false;
   if (!oldVersion || !oldVersion.properties) return false;
   // Assumption: Place features with edited wikidata tag need to flagged
   // Target: Finding suspicious edits that mistag wikidata value

--- a/comparators/name_modified.js
+++ b/comparators/name_modified.js
@@ -23,7 +23,7 @@ function name_modified(newVersion, oldVersion) {
   var result = {};
   var cfVersion = 2;
 
-  if (!newVersion || !oldVersion) {
+  if (newVersion.deleted || !oldVersion) {
     return result;
   }
   var newVersionNames = {};

--- a/comparators/name_unmatches_with_wikidata.js
+++ b/comparators/name_unmatches_with_wikidata.js
@@ -29,7 +29,7 @@ function getWikidataAliasNames(feature, id) {
 }
 
 function nameUnmatchesWithWikidata(newVersion, oldVersion, callback) {
-  if (!newVersion) return callback(null, false);
+  if (newVersion.deleted) return callback(null, false);
 
   // Check if feature is newly created.
   if (newVersion.properties['osm:version'] !== 1) {

--- a/comparators/null_island.js
+++ b/comparators/null_island.js
@@ -8,7 +8,7 @@ module.exports = nullIsland;
 
 function nullIsland(newVersion, oldVersion) {
   if (
-    !newVersion ||
+    newVersion.deleted ||
     !newVersion.hasOwnProperty('geometry') ||
     newVersion['geometry'] === null
   ) {

--- a/comparators/osm_landmarks.js
+++ b/comparators/osm_landmarks.js
@@ -10,7 +10,7 @@ module.exports = osmLandmarks;
 function osmLandmarks(newVersion, oldVersion, callback) {
   var featureID, featureType;
 
-  if (newVersion && newVersion.properties && ('osm:id' in newVersion.properties) && ('osm:type' in newVersion.properties)) {
+  if (!newVersion.deleted && newVersion.properties && ('osm:id' in newVersion.properties) && ('osm:type' in newVersion.properties)) {
     featureID = String(newVersion.properties['osm:id']);
     featureType = newVersion.properties['osm:type'];
   } else if (oldVersion && oldVersion.properties && ('osm:id' in oldVersion.properties) && ('osm:type' in oldVersion.properties)) {

--- a/comparators/path_road_changed.js
+++ b/comparators/path_road_changed.js
@@ -18,16 +18,16 @@ function isPathRoad(feature) {
 }
 
 function pathRoadChanged(newVersion, oldVersion) {
-  if (!oldVersion && !newVersion) {
+  if (!oldVersion && newVersion.deleted) {
     return false;
   }
 
-  if (oldVersion && !newVersion) {
+  if (oldVersion && newVersion.deleted) {
     // Don't care about path road deletions.
     return false;
   }
 
-  if (!oldVersion && newVersion) {
+  if (!oldVersion && !newVersion.deleted) {
     if (isPathRoad(newVersion)) {
       return {
         'result:path_road_changed': {
@@ -37,7 +37,7 @@ function pathRoadChanged(newVersion, oldVersion) {
     }
   }
 
-  if (oldVersion && newVersion) {
+  if (oldVersion && !newVersion.deleted) {
     var newHighwayType = getHighwayType(newVersion);
     var oldHighwayType = getHighwayType(oldVersion);
 

--- a/comparators/place_edited.js
+++ b/comparators/place_edited.js
@@ -16,7 +16,7 @@ var _ = require('lodash');
   - One of the feature's `name*` tags changes or is removed
 */
 function placeEdited(newVersion, oldVersion) {
-  var isDeleted = !newVersion;
+  var isDeleted = newVersion.deleted;
   var isAdded = !oldVersion;
   var isPlace, geometryChanged, nameChanged;
   if (isAdded) {
@@ -54,7 +54,7 @@ function getIsPlace(geojson) {
 }
 
 function getGeometryChanged(newVersion, oldVersion) {
-  if (!newVersion || !oldVersion) {
+  if (newVersion.deleted || !oldVersion) {
     return false;
   }
   var oldGeom = oldVersion.geometry;
@@ -65,7 +65,7 @@ function getGeometryChanged(newVersion, oldVersion) {
 }
 
 function getNameChanged(newVersion, oldVersion) {
-  if (!newVersion || !oldVersion) {
+  if (newVersion.deleted || !oldVersion) {
     return false;
   }
   var nameChanged = false;

--- a/comparators/pokemon_edits.js
+++ b/comparators/pokemon_edits.js
@@ -9,11 +9,11 @@ function hasPokename(name) {
 }
 
 function pokemonEdits(newVersion, oldVersion) {
-  if (!newVersion && !oldVersion) {
+  if (newVersion.deleted && !oldVersion) {
     // None of old version or new Version present
     return false;
   }
-  if (newVersion) {
+  if (!newVersion.deleted) {
     var pass = filtered_tags.reduce(function(accum, tag) {
       return (tag in newVersion.properties) || accum;
     }, false);

--- a/comparators/pokemon_footway.js
+++ b/comparators/pokemon_footway.js
@@ -36,7 +36,7 @@ function pokemonFootway(newVersion, oldVersion, callback) {
   // Yeah. moment.js is wierd, month start from zero
   var newUserDate = moment([2016, 11, 23]);
 
-  if (newVersion && newVersion.properties && newVersion.properties.highway === 'footway' && newVersion.properties['osm:version'] === 1) {
+  if (!newVersion.deleted && newVersion.properties && newVersion.properties.highway === 'footway' && newVersion.properties['osm:version'] === 1) {
     getAccountCreated(newVersion.properties['osm:uid'], function (error, accountCreated) {
       if (error) {
         console.log(String(error));

--- a/comparators/water_feature_by_new_user.js
+++ b/comparators/water_feature_by_new_user.js
@@ -33,7 +33,7 @@ function waterFeatureByNewUser(newVersion, oldVersion, callback) {
   // What is the number of changesets of a user to be considered a new user?
   var MINIMUM_CHANGESET_COUNT = 10;
 
-  if (!newVersion || newVersion.properties['osm:version'] !== 1) return callback(null, false);
+  if (newVersion.deleted || newVersion.properties['osm:version'] !== 1) return callback(null, false);
 
   if (isWaterFeature(newVersion)) {
     var user = newVersion.properties['osm:user'];

--- a/comparators/wikidata_wikipedia_tag_deleted.js
+++ b/comparators/wikidata_wikipedia_tag_deleted.js
@@ -3,7 +3,7 @@
 module.exports = wikidata_wikipedia_tag_deleted;
 
 function wikidata_wikipedia_tag_deleted(newVersion, oldVersion) {
-  if (!newVersion || !newVersion.properties) return false;
+  if (newVersion .deleted || !newVersion.properties) return false;
   if (!oldVersion || !oldVersion.properties) return false;
 
   if (('wikidata' in oldVersion.properties && !('wikidata' in newVersion.properties)) ||

--- a/tests/basicFixture.json
+++ b/tests/basicFixture.json
@@ -59,7 +59,7 @@
                 },
                 "geometry": null
             },
-            "newVersion": null
+            "newVersion": {"deleted": true}
         },
         {
             "description": "Fixture with old Version and new Version and non null geometries",

--- a/tests/fixtures/added_place.json
+++ b/tests/fixtures/added_place.json
@@ -3,7 +3,7 @@
   "fixtures": [
     {
       "description": "No old version, new version",
-      "newVersion": null,
+      "newVersion": {"deleted": true},
       "oldVersion": null,
       "expectedResult": false
     },

--- a/tests/fixtures/common.json
+++ b/tests/fixtures/common.json
@@ -3,7 +3,27 @@
     "fixtures": [
         {
             "description": "Test newVersion and oldVersion is null",
-            "newVersion": null,
+            "newVersion": {"deleted": true},
+            "oldVersion": null
+        },
+        {
+            "description": "Test oldVersion is null",
+            "newVersion": {
+                "properties": {
+                    "id": 158230039,
+                    "type": "node",
+                    "typeId": 1,
+                    "tags": {},
+                    "refs": [],
+                    "version": 1,
+                    "timestamp": 1455477064000,
+                    "uid": 3627372,
+                    "user": "ELBORICUA61357",
+                    "changeset": 37210478,
+                    "lat": 42.8864468,
+                    "lon": -78.8783689                    
+                }
+            },
             "oldVersion": null
         },
         {
@@ -21,15 +41,10 @@
                     "user": "ELBORICUA61357",
                     "changeset": 37210478,
                     "lat": 42.8864468,
-                    "lon": -78.8783689,
-                    "deleted": true
-                }
+                    "lon": -78.8783689
+                },
+                "deleted": true
             },
-            "oldVersion": null
-        },
-        {
-            "description": "Test oldVersion is null",
-            "newVersion": null,
             "oldVersion": {
                 "properties": {
                     "id": 158230039,
@@ -43,8 +58,7 @@
                     "user": "ELBORICUA61357",
                     "changeset": 37210478,
                     "lat": 42.8864468,
-                    "lon": -78.8783689,
-                    "deleted": true
+                    "lon": -78.8783689
                 }
             }
         }

--- a/tests/fixtures/common_tag_values.json
+++ b/tests/fixtures/common_tag_values.json
@@ -3,7 +3,7 @@
     "fixtures": [
         {
             "description": "Feature with no new version and old version",
-            "newVersion": {},
+            "newVersion": {"deleted": true},
             "oldVersion": {},
             "expectedResult": false
         },

--- a/tests/fixtures/disputed_border_deleted.json
+++ b/tests/fixtures/disputed_border_deleted.json
@@ -3,7 +3,7 @@
   "fixtures": [
   {
     "description": "Checks for deleted disputed borders",
-    "newVersion": null ,
+    "newVersion": {"deleted": true} ,
     "oldVersion": {
         "type": "Feature",
         "id": "way!304171558!6",

--- a/tests/fixtures/major_lake_modified.json
+++ b/tests/fixtures/major_lake_modified.json
@@ -539,7 +539,7 @@
     },
     {
       "description": "major lake not modified",
-      "newVersion": null,
+      "newVersion": {"deleted": true},
       "oldVersion": {
         "type": "Feature",
         "id": "way!90800153!23",

--- a/tests/fixtures/major_road_changed.json
+++ b/tests/fixtures/major_road_changed.json
@@ -543,7 +543,7 @@
     },
     {
       "description": "major road deleted",
-      "newVersion": null,
+      "newVersion": {"deleted": true},
       "oldVersion": {
         "type": "Feature",
         "id": "way!90800153!23",

--- a/tests/fixtures/modified_monument.json
+++ b/tests/fixtures/modified_monument.json
@@ -39,7 +39,7 @@
         },
         {
             "description": "Checks if monument > version 10 is deleted",
-            "newVersion": null,
+            "newVersion": {"deleted": true},
             "oldVersion": {
                 "type": "Feature",
                 "properties": {

--- a/tests/fixtures/osm_landmarks.json
+++ b/tests/fixtures/osm_landmarks.json
@@ -4,7 +4,7 @@
     {
       "description": "Test empty feature versions",
       "expectedResult": false,
-      "newVersion": null,
+      "newVersion": {"deleted": true},
       "oldVersion": null
     },
     {
@@ -40,7 +40,7 @@
       "expectedResult": {
         "result:osm_landmarks": true
       },
-      "newVersion": null,
+      "newVersion": {"deleted": true},
       "oldVersion": {
         "type": "Feature",
         "properties": {
@@ -53,7 +53,7 @@
     {
       "description": "Test lake not present in landmarks",
       "expectedResult": false,
-      "newVersion": null,
+      "newVersion": {"deleted": true},
       "oldVersion": {
         "type": "Feature",
         "properties": {
@@ -81,7 +81,7 @@
     {
       "description": "Test airport not present in landmarks",
       "expectedResult": false,
-      "newVersion": null,
+      "newVersion": {"deleted": true},
       "oldVersion": {
         "type": "Feature",
         "properties": {
@@ -109,7 +109,7 @@
     {
       "description": "Test restaurant not present in landmarks",
       "expectedResult": false,
-      "newVersion": null,
+      "newVersion": {"deleted": true},
       "oldVersion": {
         "type": "Feature",
         "properties": {

--- a/tests/index.js
+++ b/tests/index.js
@@ -31,7 +31,7 @@ test('Test basic fixture', function(assert) {
     var compareFunction = comparators[comparator];
     var jsonData = JSON.parse(fs.readFileSync(path.join(__dirname, '/basicFixture.json'), 'utf-8'));
     jsonData.fixtures.forEach(function(fixture) {
-      comparatorQueue.defer(compareFunction, fixture.oldVersion, fixture.newVersion);
+      comparatorQueue.defer(compareFunction, fixture.newVersion, fixture.oldVersion);
     });
   });
   comparatorQueue.awaitAll(function(err, result) {

--- a/tests/test_compare_function.js
+++ b/tests/test_compare_function.js
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var path = require('path');
 var queue = require('queue-async');
+var comparators = require('../index');
 
 if (process.argv.length !== 3) {
   console.log('\nUsage: node test_compare_function.js fixture_filename\n');
@@ -11,8 +12,7 @@ if (process.argv.length !== 3) {
 
 var filename = process.argv[2];
 var jsonData = JSON.parse(fs.readFileSync(path.join('.', filename), 'utf-8'));
-var compareFunctionPath = path.join('../', 'comparators', jsonData.compareFunction);
-var compareFunction = require(compareFunctionPath);
+var compareFunction = comparators[jsonData.compareFunction];
 
 jsonData.fixtures.forEach(function (fixture) {
   compareFunction(fixture.newVersion, fixture.oldVersion, function(error, result) {


### PR DESCRIPTION
Earlier a feature deleted was checked for null newVersion. But as per the chat a/ @batpad and @lukasmartinelli , the deleted feature should be same as old version, with the additional flag `deleted:true`. This version of osm-compare handles the deleted feature in this manner.

cc @bkowshik 