### PR TITLE
change user of pokemon_footway tests

### DIFF
--- a/tests/fixtures/pokemon_footway.json
+++ b/tests/fixtures/pokemon_footway.json
@@ -8,7 +8,7 @@
         "properties": {
           "highway": "footway",
           "osm:version": 4,
-          "osm:uid": 5008734
+          "osm:uid": 5017521
         },
         "geometry": {
           "type": "LineString",
@@ -38,7 +38,7 @@
         "properties": {
           "highway": "primary",
           "osm:version": 4,
-          "osm:uid": 5008734
+          "osm:uid": 5017521
         },
         "geometry": {
           "type": "LineString",
@@ -98,7 +98,7 @@
         "properties": {
           "highway": "footway",
           "osm:version": 1,
-          "osm:uid": 5008734
+          "osm:uid": 5017521
         },
         "geometry": {
           "type": "LineString",


### PR DESCRIPTION
One test was failing on some timezones because the user `5008734` has `account_created="2016-12-23T01:11:37Z"`, but moment.js is considering the timezone of the machine that is running the test. On my machine, for example, it prints that `account_created` date: `moment("2016-12-22T23:11:37.000")`. So I replaced the user `5008734` by the user `5017521`, that was created on `2016-12-24T17:10:32Z`.
