### PR TITLE
Compare function for name and ref changes 

### DIFF
--- a/comparators/name_ref_changes.js
+++ b/comparators/name_ref_changes.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var MAJOR_ROAD_TYPES = ['motorway', 'trunk', 'motorway_link', 'trunk_link'];
+
+function getHighwayType(feature) {
+  return feature.properties.highway;
+}
+
+function isMajorRoad(feature) {
+  var highwayType = getHighwayType(feature);
+  return MAJOR_ROAD_TYPES.indexOf(highwayType) !== -1;
+}
+
+function nameRefChanged(newVersion, oldVersion) {
+  if (!oldVersion || newVersion.deleted) {
+    return false;
+  }
+
+  if (isMajorRoad(oldVersion)) {
+    if (
+      oldVersion.properties.name !== newVersion.properties.name ||
+      oldVersion.properties.ref !== newVersion.properties.ref
+    ) {
+      return {
+        'result:name_ref_changes': true
+      };
+    }
+  }
+  return false;
+}
+
+module.exports = nameRefChanged;

--- a/index.js
+++ b/index.js
@@ -61,5 +61,6 @@ module.exports = {
   ),
   motorway_trunk_geometry_changed: wrapsync(
     require('./comparators/motorway_trunk_geometry_changed.js')
-  )
+  ),
+  name_ref_changes: wrapsync(require('./comparators/name_ref_changes.js'))
 };

--- a/tests/fixtures/name_ref_changes.json
+++ b/tests/fixtures/name_ref_changes.json
@@ -1,0 +1,97 @@
+{
+  "compareFunction": "name_ref_changes",
+  "fixtures": [
+    {
+      "description": "Case:1 motorway geometry modified. Should be flagged",
+      "newVersion": {
+        "type": "Feature",
+        "id": "way!90800153!24",
+        "properties": {
+          "AND_a_nosr_r": "15062474",
+          "AND:importance_level": "2",
+          "highway": "motorway",
+          "name": "23rd Street",
+          "ref": "I 23",
+          "osm:type": "way",
+          "osm:id": 90800153,
+          "osm:version": 25,
+          "osm:changeset": 44390158,
+          "osm:timestamp": 1481696445000,
+          "osm:uid": 3479270,
+          "osm:user": "nammala"
+        },
+        "geometry": {
+          "type": "LineString",
+          "coordinates": [
+            [
+              83.3348845,
+              17.7221054
+            ],
+            [
+              83.3346842,
+              17.7221352
+            ],
+            [
+              83.3342895,
+              17.7221956
+            ],
+            [
+              83.3339606,
+              17.7222435
+            ],
+            [
+              83.3337141,
+              17.7222982
+            ]
+          ]
+        }
+      },
+      "oldVersion": {
+        "type": "Feature",
+        "id": "way!90800153!24",
+        "properties": {
+          "AND_a_nosr_r": "15062474",
+          "AND:importance_level": "2",
+          "highway": "motorway",
+          "osm:type": "way",
+          "osm:id": 90800153,
+          "name": "24th Street",
+          "ref": "I 24",
+          "osm:version": 24,
+          "osm:changeset": 44390158,
+          "osm:timestamp": 1481696445000,
+          "osm:uid": 3479270,
+          "osm:user": "nammala"
+        },
+        "geometry": {
+          "type": "LineString",
+          "coordinates": [
+            [
+              73.3348845,
+              17.7221054
+            ],
+            [
+              83.3346842,
+              17.7221352
+            ],
+            [
+              83.3342895,
+              17.7221956
+            ],
+            [
+              83.3339606,
+              17.7222435
+            ],
+            [
+              83.3337141,
+              17.7222982
+            ]
+          ]
+        }
+      },
+      "expectedResult": {
+        "result:name_ref_changes": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
@amishas157 The purpose of the this cf is to detect changes to the `name` and `ref` tags of motorway and trunk roads. Can you review this compare function and merge? Thank you!


cc @maning @manoharuss  