### PR TITLE
exclude routes with name < 121 chars from "very long name" detection

### DIFF
--- a/comparators/very_long_name.js
+++ b/comparators/very_long_name.js
@@ -9,7 +9,17 @@ function veryLongName(newVersion, oldVersion) {
     newVersion.properties.hasOwnProperty('name') &&
     newVersion.properties['name'].length > 80
   ) {
-    return {'result:very_long_name': true};
+    if (
+      newVersion.properties.hasOwnProperty('type') &&
+      newVersion.properties.hasOwnProperty('osm:type') &&
+      newVersion.properties['type'] === 'route' &&
+      newVersion.properties['osm:type'] === 'relation' &&
+      newVersion.properties['name'].length < 121
+    ) {
+      return false;
+    } else {
+      return {'result:very_long_name': true};
+    }
   } else {
     return false;
   }

--- a/tests/fixtures/very_long_name.json
+++ b/tests/fixtures/very_long_name.json
@@ -1,4 +1,4 @@
-{
+  {
   "compareFunction": "very_long_name",
   "fixtures": [
     {
@@ -44,6 +44,36 @@
         "type": "Feature",
         "properties": {
           "name": "A very long name with more than eighty characters. Eighty one chars to be precise"
+        },
+        "geometry": null
+      },
+      "oldVersion": null
+    },
+    {
+      "description": "Test route whose name has 88 characters",
+      "expectedResult": false,
+      "newVersion": {
+        "type": "Feature",
+        "properties": {
+          "name": "Bus MKK-68 (1-2) Gelnhausen Bahnhof ⇒ Langenselbold Bahnhof über Gelnhausen Schulzentrum",
+          "route": "bus",
+          "type":"route",
+          "osm:type": "relation"
+        },
+        "geometry": null
+      },
+      "oldVersion": null
+    },
+    {
+      "description": "Test route whose name has 121 characters",
+      "expectedResult": {"result:very_long_name": true},
+      "newVersion": {
+        "type": "Feature",
+        "properties": {
+          "name": "Linha 526 - Terminal Vila Velha / Terminal Campo Grande - via Vasco da Gama / Expedito Garcia / Centro / Avenida Sessenta",
+          "route": "bus",
+          "type":"route",
+          "osm:type": "relation"
         },
         "geometry": null
       },


### PR DESCRIPTION
It is common that bus and other types of routes have long names, so this excludes them from this detection.