### PR TITLE
Missing primary tag

### DIFF
--- a/comparators/common_tag_values.js
+++ b/comparators/common_tag_values.js
@@ -2,37 +2,9 @@
 
 var fs = require('fs');
 var join = require('path').join;
+const primaryTags = require('../lib/primary_tags').primaryTags;
 
 module.exports = commonTagValues;
-
-var primaryTags = [
-  'aerialway',
-  'aeroway',
-  'amenity',
-  'barrier',
-  'boundary',
-  'building',
-  'craft',
-  'emergency',
-  'geological',
-  'highway',
-  'historic',
-  'landuse',
-  'leisure',
-  'man_made',
-  'military',
-  'natural',
-  'office',
-  'place',
-  'power',
-  'public_transport',
-  'railway',
-  'route',
-  'shop',
-  'sport',
-  'tourism',
-  'waterway'
-];
 
 function commonTagValues(newVersion, oldVersion) {
   var result = false;

--- a/comparators/missing_primary_tag.js
+++ b/comparators/missing_primary_tag.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var fs = require('fs');
+var join = require('path').join;
+const primaryTags = require('../lib/primary_tags').primaryTags;
+
+module.exports = missingPrimaryTag;
+
+function missingPrimaryTag(newVersion, oldVersion) {
+  if (newVersion.deleted || !newVersion.properties) return false;
+
+  const feature_tags = Object.keys(newVersion.properties);
+  const feature_primary_tags = primaryTags.filter(
+    i => feature_tags.filter(t => t === i).length > 0
+  );
+
+  if (feature_primary_tags.length > 0) return false;
+  return {'result:missing_primary_tag': true};
+}

--- a/comparators/missing_primary_tag.js
+++ b/comparators/missing_primary_tag.js
@@ -2,12 +2,19 @@
 
 var fs = require('fs');
 var join = require('path').join;
-const primaryTags = require('../lib/primary_tags').primaryTags;
+var primaryTags = require('../lib/primary_tags').primaryTags;
 
 module.exports = missingPrimaryTag;
 
 function missingPrimaryTag(newVersion, oldVersion) {
   if (newVersion.deleted || !newVersion.properties) return false;
+
+  primaryTags = primaryTags.concat([
+    'addr:street',
+    'addr:interpolation',
+    'addr:full',
+    'addr:postcode'
+  ]);
 
   const feature_tags = Object.keys(newVersion.properties);
   const feature_primary_tags = primaryTags.filter(

--- a/comparators/motorway_trunk_geometry_changed.js
+++ b/comparators/motorway_trunk_geometry_changed.js
@@ -1,14 +1,7 @@
 'use strict';
 
 var deepEquals = require('deep-equals');
-var MAJOR_ROAD_TYPES = [
-  'motorway',
-  'trunk',
-  'motorway_link',
-  'trunk_link',
-  'primary',
-  'primary_link'
-];
+var MAJOR_ROAD_TYPES = ['motorway', 'trunk', 'motorway_link', 'trunk_link'];
 
 function getHighwayType(feature) {
   return feature.properties.highway;

--- a/index.js
+++ b/index.js
@@ -38,6 +38,9 @@ module.exports = {
   invalid_tag_combination: require('./comparators/invalid_tag_combination'),
   water_feature_by_new_user: require('./comparators/water_feature_by_new_user'),
   common_tag_values: wrapsync(require('./comparators/common_tag_values.js')),
+  missing_primary_tag: wrapsync(
+    require('./comparators/missing_primary_tag.js')
+  ),
   example: require('./comparators/example.js'),
   added_website: wrapsync(require('./comparators/added_website.js')),
   wikidata_distance_with_osm: wrapsync(

--- a/lib/primary_tags.js
+++ b/lib/primary_tags.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const primaryTags = [
+  'aerialway',
+  'aeroway',
+  'amenity',
+  'barrier',
+  'boundary',
+  'building',
+  'craft',
+  'emergency',
+  'geological',
+  'highway',
+  'historic',
+  'landuse',
+  'leisure',
+  'man_made',
+  'military',
+  'natural',
+  'office',
+  'place',
+  'power',
+  'public_transport',
+  'railway',
+  'route',
+  'shop',
+  'sport',
+  'tourism',
+  'waterway'
+];
+
+exports.primaryTags = primaryTags;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/osm-compare",
-  "version": "9.2.0",
+  "version": "9.3.0",
   "description": "Compare a features new and old versions in GeoJSON",
   "main": "index.js",
   "scripts": {

--- a/tests/fixtures/missing_primary_tag.json
+++ b/tests/fixtures/missing_primary_tag.json
@@ -9,15 +9,33 @@
         },
         {
             "description": "Feature with invalid highway value but with correct key",
-            "newVersion": {"highway": "random"},
+            "newVersion": {"properties": {"highway": "random"}},
             "oldVersion": {},
             "expectedResult": false
         },
         {
             "description": "Feature with invalid shop value but with correct key",
-            "newVersion": {"shop": "random_shop"},
+            "newVersion": {"properties":{"shop": "random_shop"}},
             "oldVersion": {},
             "expectedResult": false
+        },
+        {
+            "description": "Feature with correct address tags",
+            "newVersion": {
+                "properties": {"addr:street": "Via 1", "addr:housenumber": 123}
+            },
+            "oldVersion": {},
+            "expectedResult": false
+        },
+        {
+            "description": "Feature with missing addr key",
+            "newVersion": {
+                "properties": {"addr:country": "Fiji", "addr:housenumber": 123}
+            },
+            "oldVersion": {},
+            "expectedResult": {
+                "result:missing_primary_tag": true
+            }
         },
         {
             "description": "Feature with valid highway tag",
@@ -51,7 +69,9 @@
         },
         {
             "description": "Feature with invalid amenity key",
-            "newVersion": {"properties": {"amennity" : "school", "name": "The school"}},
+            "newVersion": {
+                "properties": {"amennity" : "school", "name": "The school"}
+            },
             "oldVersion": {},
             "expectedResult": {
                 "result:missing_primary_tag": true

--- a/tests/fixtures/missing_primary_tag.json
+++ b/tests/fixtures/missing_primary_tag.json
@@ -1,0 +1,61 @@
+{
+    "compareFunction": "missing_primary_tag",
+    "fixtures": [
+        {
+            "description": "Feature with no new version and old version",
+            "newVersion": {"deleted": true},
+            "oldVersion": {},
+            "expectedResult": false
+        },
+        {
+            "description": "Feature with invalid highway value but with correct key",
+            "newVersion": {"highway": "random"},
+            "oldVersion": {},
+            "expectedResult": false
+        },
+        {
+            "description": "Feature with invalid shop value but with correct key",
+            "newVersion": {"shop": "random_shop"},
+            "oldVersion": {},
+            "expectedResult": false
+        },
+        {
+            "description": "Feature with valid highway tag",
+            "newVersion": {"properties": {"highway" : "primary"}},
+            "oldVersion": {},
+            "expectedResult": false
+        },
+        {
+            "description": "Feature with invalid highway key",
+            "newVersion": {"properties": {"higway" : "residential"}},
+            "oldVersion": {},
+            "expectedResult": {
+                "result:missing_primary_tag": true
+            }
+        },
+        {
+            "description": "Feature with only area=yes",
+            "newVersion": {"properties": {"area" : "yes"}},
+            "oldVersion": {},
+            "expectedResult": {
+                "result:missing_primary_tag": true
+            }
+        },
+        {
+            "description": "Feature without primary tag",
+            "newVersion": {"properties": {"area" : "yes", "name": "The Shop"}},
+            "oldVersion": {},
+            "expectedResult": {
+                "result:missing_primary_tag": true
+            }
+        },
+        {
+            "description": "Feature with invalid amenity key",
+            "newVersion": {"properties": {"amennity" : "school", "name": "The school"}},
+            "oldVersion": {},
+            "expectedResult": {
+                "result:missing_primary_tag": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Get all objects that doesn't have a primary tag. Function suggested by @aawiseman